### PR TITLE
Optimize removal of filter disabled conditions

### DIFF
--- a/src/EntityFramework.DynamicFilters.Shared/DynamicFilterExtensions.cs
+++ b/src/EntityFramework.DynamicFilters.Shared/DynamicFilterExtensions.cs
@@ -964,7 +964,7 @@ namespace EntityFramework.DynamicFilters
 #if (DEBUG)
                     throw new ApplicationException(string.Format("Failed to find start or end index of remove filter clause for parameter name {0}", param.ParameterName));
 #else
-                    return;
+                    break;
 #endif
                 }
 

--- a/src/EntityFramework.DynamicFilters.Shared/DynamicFilterExtensions.cs
+++ b/src/EntityFramework.DynamicFilters.Shared/DynamicFilterExtensions.cs
@@ -936,7 +936,8 @@ namespace EntityFramework.DynamicFilters
             //  and found a case (covered by test case "AccountAndBlogEntries") where an embedded select was returning these parameters!
             StringBuilder b = new StringBuilder();
             var curIdx = 0;
-            while ((paramIdx = command.CommandText.IndexOf(param.ParameterName + " IS NOT NULL", curIdx, StringComparison.OrdinalIgnoreCase)) != -1)
+            while ((curIdx < command.CommandText.Length) &&
+                   (paramIdx = command.CommandText.IndexOf(param.ParameterName + " IS NOT NULL", curIdx, StringComparison.OrdinalIgnoreCase)) != -1)
             {
                 int startIdx = command.CommandText.LastIndexOf("or", paramIdx, StringComparison.OrdinalIgnoreCase);
                 int endIdx = command.CommandText.IndexOf(')', paramIdx);


### PR DESCRIPTION
Profiling our db code, we saw a hotspot in the '''RemoveFilterDisabledConditionFromQuery''' method. There are a few optimizations able to be made here:

- It should be safe to use the much more efficient OrdinalIgnoreCase string comparison since parameters are of well-known format with no unusual characters.
- Doing IndexOf with type char is more efficient than using a string with one character.
- Keep track of how far we have searched in the command so we don't have to seek the whole string on each iteration.
- Use StringBuilder for greatly reduced memory allocations on larger command texts where many removes are performed. If using NetStandard it would be possible to work with Span instead for minimal memory usage, but since this is dual-targeting to .Net Framework I did not investigate it.

Benchmarks on EF-generated command strings from our product yields somewhere between 10-100x time improvement for this method over original code. Memory allocations may cause few KB more allocations on very small queries, but saves several megabytes on large queries with many replacements.